### PR TITLE
feat: profile updates and studio check-in features

### DIFF
--- a/app/profile/favorites.tsx
+++ b/app/profile/favorites.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../src/providers/ThemeProvider';
+
+export default function FavoritesScreen() {
+  const router = useRouter();
+  const { getBackgroundColor, getSurfaceColor, getTextColor, getBorderColor } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: getBackgroundColor() }]}>
+      <View style={[styles.header, { backgroundColor: getSurfaceColor(), borderBottomColor: getBorderColor() }]}> 
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={24} color={getTextColor('primary')} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: getTextColor('primary') }]}>Favoriten</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.placeholderText, { color: getTextColor('secondary') }]}>Deine gespeicherten Studios und Kurse erscheinen hier.</Text>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 60,
+    paddingBottom: 20,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: { fontSize: 20, fontWeight: 'bold' },
+  headerSpacer: { width: 40 },
+  content: {
+    padding: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholderText: { fontSize: 16, textAlign: 'center' },
+});

--- a/app/profile/referral.tsx
+++ b/app/profile/referral.tsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Share } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../src/providers/ThemeProvider';
+import { useAppStore } from '../../src/store';
+
+export default function ReferralScreen() {
+  const router = useRouter();
+  const currentUser = useAppStore(state => state.user);
+  const { getBackgroundColor, getSurfaceColor, getTextColor, getBorderColor } = useTheme();
+
+  const referralCode = useMemo(() => currentUser?.uid?.slice(0,8) || 'CODE1234', [currentUser]);
+
+  const handleShare = async () => {
+    try {
+      await Share.share({
+        message: `Tritt PassFit bei und nutze meinen Code ${referralCode}!`,
+      });
+    } catch (err) {
+      console.error('Share error', err);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: getBackgroundColor() }]}> 
+      <View style={[styles.header, { backgroundColor: getSurfaceColor(), borderBottomColor: getBorderColor() }]}> 
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={24} color={getTextColor('primary')} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: getTextColor('primary') }]}>Weitersagen</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.placeholderText, { color: getTextColor('secondary') }]}>Teile den Code mit deinen Freunden und erhalte einen Bonus.</Text>
+        <View style={[styles.codeContainer, { borderColor: getBorderColor() }]}> 
+          <Text style={[styles.codeText, { color: getTextColor('primary') }]}>{referralCode}</Text>
+        </View>
+        <TouchableOpacity style={styles.shareButton} onPress={handleShare}>
+          <Ionicons name="share-outline" size={20} color="#fff" />
+          <Text style={styles.shareButtonText}>Teilen</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 60,
+    paddingBottom: 20,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: { fontSize: 20, fontWeight: 'bold' },
+  headerSpacer: { width: 40 },
+  content: {
+    padding: 24,
+    alignItems: 'center',
+  },
+  placeholderText: { fontSize: 16, textAlign: 'center', marginBottom: 24 },
+  codeContainer: {
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginBottom: 24,
+  },
+  codeText: { fontSize: 24, fontWeight: 'bold' },
+  shareButton: {
+    flexDirection: 'row',
+    backgroundColor: '#6B46C1',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  shareButtonText: { color: '#fff', fontSize: 16, fontWeight: '600', marginLeft: 8 },
+});

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "expo-dev-client": "~5.2.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
+    "expo-image-picker": "~16.1.6",
     "expo-localization": "^16.1.6",
     "expo-location": "^18.1.6",
     "expo-router": "~5.1.4",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -264,7 +264,9 @@
     "vip": "VIP Tarif",
     "gold": "Gold Tarif",
     "vipPrice": "€ 99 / Monat",
-    "goldPrice": "€ 49 / Monat"
+    "goldPrice": "€ 49 / Monat",
+    "purchaseSuccess": "Abonnement erfolgreich aktiviert.",
+    "purchaseError": "Checkout konnte nicht gestartet werden. Bitte versuche es erneut."
   },
   "accessibility": {
     "searchStudios": "Studios suchen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -114,7 +114,9 @@
     "vip": "VIP Plan",
     "gold": "Gold Plan",
     "vipPrice": "€ 99 / Month",
-    "goldPrice": "€ 49 / Month"
+    "goldPrice": "€ 49 / Month",
+    "purchaseSuccess": "Subscription activated successfully.",
+    "purchaseError": "Could not start checkout. Please try again."
   },
   "accessibility": {
     "searchStudios": "Search studios",

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,5 +1,6 @@
 export { AuthService } from './auth.service';
 export { UserService } from './user.service';
+export type { CookiePreferences } from './user.service';
 export { WorkoutService } from './workout.service';
 export { StudioService } from './studio.service';
 export { SubscriptionService } from './subscription.service';


### PR DESCRIPTION
## Summary
- enable changing avatar with image picker and save via `UserService`
- add Favorites screen placeholder and Referral sharing screen
- implement studio check-in, favorite toggle and subscription validation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: TS6133 unused imports, TS7030 not all code paths return value)*

------
https://chatgpt.com/codex/tasks/task_e_688dc89739f8832c922079605d837e89